### PR TITLE
Fix typo: 46 + 4 * 240 = 1006 instead of 1008

### DIFF
--- a/src/ppu/composite.md
+++ b/src/ppu/composite.md
@@ -1,7 +1,7 @@
 # Layer compositing
 
 Compositing of the background, sprite and backdrop layers begins after a wait period of 46 cycles.
-The PPU then composites an output pixel every four cycles. The last pixel will be completed on cycle #1006 (`46 + 4 * 240 = 1008`).
+The PPU then composites an output pixel every four cycles. The last pixel will be completed on cycle #1006 (`46 + 4 * 240 = 1006`).
 It does this during all visible scanlines (0 to 159) and always composites pixels for the current scanline.
 
 For each output pixel the top two opaque layers for that pixel are extracted. Then up to two Palette RAM (PRAM) accesses are performed, to resolve palette indices from the background or sprite layers to 16-bit colors or to get the backdrop colour. The first PRAM access  resolves the colour for the top-most layer and the second PRAM access the colour for the second top-most layer.


### PR DESCRIPTION
There's a typo on the result of that calculation.